### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,5 +1,7 @@
 ---
 name: Go
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/byron-janrain/uid/security/code-scanning/1](https://github.com/byron-janrain/uid/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the GitHub Actions token to the least privilege required. Since none of the actions in the provided workflow require write access, the minimal necessary permission is `contents: read`. This block can be added either at the root (applies to all jobs) or within the `build` job; root level is preferred for clarity and future job additions. Edit the file `.github/workflows/make.yml`, inserting the following block directly after the `name: Go` line and before `on:`. No changes to imports or step logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
